### PR TITLE
Update RedditScrapper URL handling

### DIFF
--- a/docs/samples/awwvision/src/main/java/com/google/cloud/servicebroker/awwvision/RedditScraper.java
+++ b/docs/samples/awwvision/src/main/java/com/google/cloud/servicebroker/awwvision/RedditScraper.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.HtmlUtils;
 
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.servicebroker.awwvision.RedditResponse.Listing;
@@ -76,7 +77,7 @@ public class RedditScraper {
         URL url;
         byte[] raw;
         try {
-          url = new URL(img.source.url);
+          url = new URL(HtmlUtils.htmlUnescape(img.source.url));
           raw = download(url);
         } catch (IOException e) {
           logger.warn("Issue in streaming image " + img.source.url, e);

--- a/docs/samples/awwvision/src/test/java/com/google/cloud/servicebroker/awwvision/RedditScraperTest.java
+++ b/docs/samples/awwvision/src/test/java/com/google/cloud/servicebroker/awwvision/RedditScraperTest.java
@@ -86,14 +86,14 @@ public class RedditScraperTest {
 
   @Test
   public void testScrape() throws Exception {
-    Image img1 = new Image(new RedditResponse.Source("http://url1"), "img1");
+    Image img1 = new Image(new RedditResponse.Source("http://url1?foo=bar&amp;baz=foo"), "img1");
     Image img2 = new Image(new RedditResponse.Source("http://url2"), "img2");
     RedditResponse redditResponse = new RedditResponse(new Data(
         new Listing[] {new Listing(new ListingData(new Preview(new Image[] {img1, img2})))}));
 
     scraper.storeAndLabel(redditResponse);
 
-    verify(storageAPI).uploadJpeg("img1.jpg", new URL("http://url1"),
+    verify(storageAPI).uploadJpeg("img1.jpg", new URL("http://url1?foo=bar&baz=foo"),
         ImmutableMap.of("label", "dog"));
     verify(storageAPI).uploadJpeg("img2.jpg", new URL("http://url2"),
         ImmutableMap.of("label", "dog"));
@@ -103,13 +103,13 @@ public class RedditScraperTest {
   public void testSelfPosts() throws Exception {
     Image img1 = new Image(new RedditResponse.Source("http://url1"), "img1");
     RedditResponse redditResponse = new RedditResponse(new Data(
-            new Listing[] {
-                    new Listing(new ListingData(new Preview(new Image[] {img1}))),
-                    new Listing(new ListingData()),
-            }));
+        new Listing[] {
+            new Listing(new ListingData(new Preview(new Image[] {img1}))),
+            new Listing(new ListingData()),
+        }));
 
     scraper.storeAndLabel(redditResponse);
     verify(storageAPI).uploadJpeg("img1.jpg", new URL("http://url1"),
-            ImmutableMap.of("label", "dog"));
+        ImmutableMap.of("label", "dog"));
   }
 }


### PR DESCRIPTION
Reddit's API now returns `&amp;` instead of `&` when representing query
parameters. Use Spring's decode function to parse any encoded values
before performing the image fetch.

Fixes #9