### PR TITLE
Update operations manager and PAS

### DIFF
--- a/src/omg-cli/config/env_config.go
+++ b/src/omg-cli/config/env_config.go
@@ -38,7 +38,7 @@ type EnvConfig struct {
 func DefaultEnvConfig() (*EnvConfig, error) {
 	c := &EnvConfig{
 		DnsZoneName:    "pcf-zone",
-		BaseImageURL:   "https://storage.cloud.google.com/ops-manager-us/pcf-gcp-2.1-build.204.tar.gz",
+		BaseImageURL:   "https://storage.cloud.google.com/ops-manager-us/pcf-gcp-2.1-build.326.tar.gz",
 		EnvName:        "pcf",
 		Region:         "us-east1",
 		Zone1:          "us-east1-b",

--- a/src/omg-cli/omg/tiles/ert/resource.go
+++ b/src/omg-cli/omg/tiles/ert/resource.go
@@ -23,9 +23,9 @@ import (
 var fullRuntime = config.Tile{
 	config.PivnetMetadata{
 		"elastic-runtime",
-		69794,
-		104972,
-		"4eb5940e0711f8de4ebf81f1031f1ff0c4c38704b07ecaa2f707962100296d0f",
+		118424,
+		158939,
+		"214da7e21a57cf851fd7c842542157af0f26fc3173ca8746377d3c890ec64243",
 	},
 	product,
 	&stemcell,
@@ -34,9 +34,9 @@ var fullRuntime = config.Tile{
 var smallRuntime = config.Tile{
 	config.PivnetMetadata{
 		"elastic-runtime",
-		69794,
-		104982,
-		"0c9892f64b7a0314f3066aaf3e45f030736a36ebbb72907d0c0368164f91a11c",
+		118424,
+		158946,
+		"ec5c879be1ca3349aef003e877083a66add34dfd3a86e6dca1dbe99f445cb2b9",
 	},
 	product,
 	&stemcell,
@@ -44,15 +44,16 @@ var smallRuntime = config.Tile{
 
 var product = config.OpsManagerMetadata{
 	"cf",
-	"2.1.0",
+	"2.1.7",
 }
 
 var stemcell = config.StemcellMetadata{
-	config.PivnetMetadata{"stemcells",
-		61940,
-		96300,
-		"b8aa5baed1d4cba84740a800ca465e29fe4469143e275044ac1b84e9ef71a326"},
-	"light-bosh-stemcell-3541.8-google-kvm-ubuntu-trusty-go_agent",
+	config.PivnetMetadata{
+		"stemcells",
+		106151,
+		145286,
+		"31f0b81919c58f71ba3427b29bdc02099808da378f938ed3d930ff5623c7d0d6"},
+	"light-bosh-stemcell-3541.30-google-kvm-ubuntu-trusty-go_agent",
 }
 
 type Tile struct{}

--- a/src/omg-tf/variables.tf
+++ b/src/omg-tf/variables.tf
@@ -20,7 +20,7 @@ variable "zones" {
 variable "opsman_image_url" {
   type        = "string"
   description = "location of ops manager image on google cloud storage"
-  default     = "https://storage.cloud.google.com/ops-manager-us/pcf-gcp-2.1-build.204.tar.gz"
+  default     = "https://storage.cloud.google.com/ops-manager-us/pcf-gcp-2.1-build.326.tar.gz"
 }
 
 variable "opsman_image_selflink" {


### PR DESCRIPTION
⬆️ Operations Manager to 2.1.6
⬆️ PAS to 2.1.7
⬆️ Stemcell to 3541.30

There's a [known issue](https://docs.pivotal.io/pcf-healthwatch/1-2/troubleshooting.html#smoke-tests-failing-on-bosh-metric-ingestion) with operations manager prior to 2.1.4 and Healthwatch, so recommend merging this at the same time as #15. 