### PR TITLE
Add Enable Compute API step

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -7,6 +7,7 @@ Follow this guide to prepare you Google Cloud Project and deployment machine.
 1. [Sign up](https://cloud.google.com/compute/docs/signup) for Google Cloud Platform
 1. Create a [new project](https://console.cloud.google.com/iam-admin/projects)
 1. Enable the [Cloud Resource Manager API](https://console.cloud.google.com/apis/api/cloudresourcemanager.googleapis.com/overview)
+1. Enable the [Compute API](https://console.cloud.google.com/apis/api/compute.googleapis.com/overview)
 1. Enable [billing](https://support.google.com/cloud/answer/6293499?hl=en#enable-billing)
 1. Verify your [existing quota](https://console.cloud.google.com/iam-admin/quotas) and file a [quota increase](https://cloud.google.com/compute/quotas) of necessary.
    - If deploying [Small Footprint Runtime](https://docs.pivotal.io/pivotalcf/1-12/customizing/small-footprint.html) (default):


### PR DESCRIPTION
The compute resources don't show up in a project until the compute API has been turned on so the quota step didn't make much sense.

It looks like the API is auto-enabled if you visit the compute page, but just to be sure add a step to explicitly enable it.