### PR TITLE
Revert "Create new destroy-existing CI step."

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,7 +5,6 @@ groups:
       - run-unit
       - prepare-project
       - generate-env
-      - destroy-existing
       - create-infrastructure
       - deploy-pcf
       - run-certification
@@ -61,7 +60,7 @@ jobs:
             params:
               file: omg-env/*.tgz
 
-  - name: destroy-existing
+  - name: create-infrastructure
     serial: true
     serial_groups: [gcp-project]
     plan:
@@ -72,22 +71,6 @@ jobs:
             resource: omg-src-in
           - trigger: true
             passed: [generate-env]
-            get: omg-env
-            resource: omg-env
-      - try:
-          do: *destroy_all
-
-  - name: create-infrastructure
-    serial: true
-    serial_groups: [gcp-project]
-    plan:
-      - aggregate:
-          - trigger: true
-            passed: [run-unit, destroy-existing]
-            get: omg-src-in
-            resource: omg-src-in
-          - trigger: true
-            passed: [generate-env, destroy-existing]
             get: omg-env
             resource: omg-env
       - aggregate:
@@ -119,10 +102,27 @@ jobs:
             file: omg-src-in/ci/tasks/push-tiles.yml
             params:
               env_file_name: ((env_file_name))
+            on_failure: &destroy_infrastructure
+              task: destroy-infrastructure
+              file: omg-src-in/ci/tasks/destroy-infrastructure.yml
+              params:
+                google_project: ((google_project))
+                google_json_key_data: ((google_json_key_data))
+                env_file_name: ((env_file_name))
           - task: deploy-pcf
             file: omg-src-in/ci/tasks/deploy-pcf.yml
             params:
               env_file_name: ((env_file_name))
+            on_failure:
+              do:
+                - &destroy_pcf
+                  task: destroy-pcf
+                  file: omg-src-in/ci/tasks/destroy-pcf.yml
+                  params:
+                    google_project: ((google_project))
+                    google_json_key_data: ((google_json_key_data))
+                    env_file_name: ((env_file_name))
+                - *destroy_infrastructure
 
   - name: run-certification
     serial: true
@@ -142,6 +142,10 @@ jobs:
         file: omg-src-in/ci/tasks/run-certification.yml
         params:
           env_file_name: ((env_file_name))
+        on_failure:
+          do: &destroy_all
+            - *destroy_pcf
+            - *destroy_infrastructure
 
   - name: destroy-all
     serial: true
@@ -156,19 +160,9 @@ jobs:
             passed: [run-certification]
             get: omg-env
             resource: omg-env
-      - do: &destroy_all
-          - task: destroy-pcf
-            file: omg-src-in/ci/tasks/destroy-pcf.yml
-            params:
-              google_project: ((google_project))
-              google_json_key_data: ((google_json_key_data))
-              env_file_name: ((env_file_name))
-          - task: destroy-infrastructure
-            file: omg-src-in/ci/tasks/destroy-infrastructure.yml
-            params:
-              google_project: ((google_project))
-              google_json_key_data: ((google_json_key_data))
-              env_file_name: ((env_file_name))
+      - do: *destroy_all
+        on_failure:
+          do: *destroy_all
 
   - name: promote-candidate-major
     serial: true


### PR DESCRIPTION
This reverts commit acac7e0b95def88aee1a81d03163391fe1a3ac5d.

`terraform.tfstate` is not preserved between pipeline executions.
Therefore, the destroy-existing step will always no nothing. Combine
this with the removal of `on_failure` means the pipeline forever gets
stuck because terraform resources `already exist`.