### PR TITLE
Added script for fetching tile metadata

### DIFF
--- a/util/pivnet_meta.sh
+++ b/util/pivnet_meta.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+slug=$1
+version=$(pivnet releases -p $1 --format json | jq -r '.[0].version')
+
+get_pivnet_meta() {
+    pivnet product-files --product-slug $1 -r $2 --format json | \
+        jq --arg slug "$1" --arg filter "$3" -r 'map(select(.aws_object_key | contains($filter))) |
+           map(.release_id = (.["_links"].download.href | capture("/releases/(?<r>[^/]+)").r)) |
+           map("\(.name):\nconfig.PivnetMetadata{\n\"\($slug)\",\n\(.release_id),\n\(.id),\n\"\(.sha256)\",\n},") | .[]'
+}
+
+echo "$1/$version"
+get_pivnet_meta $slug $version ".pivotal"
+
+read -r stemcell_slug stemcell_version <<<$(
+    pivnet release-dependencies --product-slug $slug -r $version --format json | \
+    jq -r 'map(select(.release.product.slug | contains("stemcells"))) |
+        sort_by(- .release.id)[0].release | "\(.product.slug) \(.version)"')
+
+get_pivnet_meta $stemcell_slug $stemcell_version "google"
+
+pivnet product-files --product-slug $stemcell_slug -r $stemcell_version --format json | \
+    jq -r 'map(select(.aws_object_key | contains("google")))[0].aws_object_key |
+           capture("/(?<n>[^/]+).tgz").n | "\"\(.)\","'


### PR DESCRIPTION
Script to create copy pasteable code for updating tile resource data:
```
./util/pivnet_meta.sh elastic-runtime
elastic-runtime/2.3.3
Small Footprint PAS:
config.PivnetMetadata{
"elastic-runtime",
220833,
254473,
"1ab242bff8f95598193b0c742b7d6a520628ebeb682fd949d18da5ef6c8e5c7a",
},
Pivotal Application Service:
config.PivnetMetadata{
"elastic-runtime",
220833,
254457,
"5540900a3626b092bffdb01b530791a116cf5f1022fd1b048edaeea4424318fd",
},
Ubuntu Xenial Stemcell for Google Cloud Platform 97.31:
config.PivnetMetadata{
"stemcells-ubuntu-xenial",
225315,
259369,
"6b1c333f382770a5f351362f2c8142b7fd165fe9dd96a902bd4e40006f87a650",
},
"light-bosh-stemcell-97.31-google-kvm-ubuntu-xenial-go_agent",
```