### PR TITLE
 Split ApplyChanges into two steps

### DIFF
--- a/docs/deploy-awwvision.md
+++ b/docs/deploy-awwvision.md
@@ -1,5 +1,9 @@
 # Exercise: AwwVision
 
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https%3A%2F%2Fgithub.com%2Fcf-platform-eng%2Fgcp-pcf-quickstart&page=shell&working_dir=docs%2Fsamples%2Fawwvision&tutorial=..%2F..%2Fdeploy-awwvision.md)
+
+## Introduction
+
 Now that you've [deployed PCF](./quick-deployment.md) and
 [logged in to Cloud Foundry](./login-to-pcf.md#cfapi) it's time to explore
 the platform and Google Cloud.

--- a/src/omg-cli/config/tile_definition.go
+++ b/src/omg-cli/config/tile_definition.go
@@ -29,8 +29,9 @@ type StemcellMetadata struct {
 }
 
 type OpsManagerMetadata struct {
-	Name    string
-	Version string
+	Name         string
+	Version      string
+	DependsOnPAS bool // tiles which depend on PAS but don't specify so in their metadata
 }
 
 type Tile struct {

--- a/src/omg-cli/omg/commands/deploy.go
+++ b/src/omg-cli/omg/commands/deploy.go
@@ -68,7 +68,8 @@ func (cmd *DeployCommand) run(c *kingpin.ParseContext) error {
 
 	if cmd.applyChanges {
 		steps = append(steps, step{opsMan.ApplyDirector, "ApplyDirector"})
-		steps = append(steps, step{opsMan.ApplyChanges, "ApplyChanges"})
+		steps = append(steps, step{opsMan.ApplyChangesPAS, "ApplyChangesPAS"})
+		steps = append(steps, step{opsMan.ApplyChangesSkipUnchanged, "ApplyChangesSkipUnchanged"})
 	}
 
 	return run(steps)

--- a/src/omg-cli/omg/setup/ops_manager.go
+++ b/src/omg-cli/omg/setup/ops_manager.go
@@ -70,8 +70,19 @@ func (s *OpsManager) Unlock() error {
 	}
 }
 
-func (s *OpsManager) ApplyChanges() error {
-	return s.om.ApplyChanges()
+func (s *OpsManager) ApplyChangesPAS() error {
+	var args []string
+	for _, tile := range s.tiles {
+		if !tile.Definition(s.envCfg).Product.DependsOnPAS {
+			name := tile.Definition(s.envCfg).Product.Name
+			args = append(args, fmt.Sprintf("--product-name=%s", name))
+		}
+	}
+	return s.om.ApplyChanges(args)
+}
+
+func (s *OpsManager) ApplyChangesSkipUnchanged() error {
+	return s.om.ApplyChanges([]string{"--skip-unchanged-products"})
 }
 
 func (s *OpsManager) ApplyDirector() error {

--- a/src/omg-cli/omg/tiles/ert/resource.go
+++ b/src/omg-cli/omg/tiles/ert/resource.go
@@ -45,6 +45,7 @@ var smallRuntime = config.Tile{
 var product = config.OpsManagerMetadata{
 	"cf",
 	"2.3.3",
+	false,
 }
 
 var stemcell = config.StemcellMetadata{

--- a/src/omg-cli/omg/tiles/healthwatch/resource.go
+++ b/src/omg-cli/omg/tiles/healthwatch/resource.go
@@ -31,6 +31,7 @@ var tile = config.Tile{
 	config.OpsManagerMetadata{
 		"p-healthwatch",
 		"1.3.2-build.9",
+		true,
 	},
 	&config.StemcellMetadata{
 		config.PivnetMetadata{

--- a/src/omg-cli/omg/tiles/service_broker/resource.go
+++ b/src/omg-cli/omg/tiles/service_broker/resource.go
@@ -30,6 +30,7 @@ var tile = config.Tile{
 	config.OpsManagerMetadata{
 		"gcp-service-broker",
 		"3.6.0",
+		true,
 	},
 	&config.StemcellMetadata{
 		config.PivnetMetadata{"stemcells",

--- a/src/omg-cli/omg/tiles/stackdriver_nozzle/resource.go
+++ b/src/omg-cli/omg/tiles/stackdriver_nozzle/resource.go
@@ -31,6 +31,7 @@ var tile = config.Tile{
 	config.OpsManagerMetadata{
 		"stackdriver-nozzle",
 		"2.0.1",
+		true,
 	},
 	&config.StemcellMetadata{
 		config.PivnetMetadata{"stemcells",

--- a/src/omg-cli/ops_manager/sdk.go
+++ b/src/omg-cli/ops_manager/sdk.go
@@ -166,10 +166,10 @@ func (om *Sdk) SetupBosh(configYML []byte) error {
 }
 
 // ApplyChanges deploys pending changes to Ops Manager
-func (om *Sdk) ApplyChanges() error {
+func (om *Sdk) ApplyChanges(args []string) error {
 	logWriter := commands.NewLogWriter(os.Stdout)
 	cmd := commands.NewApplyChanges(om.api, logWriter, om.logger, 10)
-	return cmd.Execute(nil)
+	return cmd.Execute(args)
 }
 
 func (om *Sdk) ApplyDirector() error {


### PR DESCRIPTION
This PR creates a workaround for the missing cf dependency of the stackdriver_nozzle tile