### PR TITLE
Don't use external_database when using Small Footprint

### DIFF
--- a/src/omg-cli/config/terraform_config.go
+++ b/src/omg-cli/config/terraform_config.go
@@ -34,14 +34,14 @@ type TerraformConfigSchema struct {
 
 	OpsManagerServiceAccountKey string
 
-	ExternalSqlIp         string `json:"sql_db_ip"`
+	ExternalSqlIp         string `json:"sql_db_ip,omitempty"`
 	ExternalSqlPort       int
-	OpsManagerSqlDbName   string `json:"opsman_sql_db_name"`
-	OpsManagerSqlUsername string `json:"opsman_sql_username"`
-	OpsManagerSqlPassword string `json:"opsman_sql_password"`
-	ERTSqlDbName          string `json:"ert_sql_db_name"`
-	ERTSqlUsername        string `json:"ert_sql_username"`
-	ERTSqlPassword        string `json:"ert_sql_password"`
+	OpsManagerSqlDbName   string `json:"opsman_sql_db_name,omitempty"`
+	OpsManagerSqlUsername string `json:"opsman_sql_username,omitempty"`
+	OpsManagerSqlPassword string `json:"opsman_sql_password,omitempty"`
+	ERTSqlDbName          string `json:"ert_sql_db_name,omitempty"`
+	ERTSqlUsername        string `json:"ert_sql_username,omitempty"`
+	ERTSqlPassword        string `json:"ert_sql_password,omitempty"`
 
 	MgmtSubnetName    string `json:"management_subnet_name"`
 	MgmtSubnetGateway string `json:"management_subnet_gateway"`

--- a/src/omg-cli/go.mod
+++ b/src/omg-cli/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gosuri/uilive v0.0.0-20170323041506-ac356e6e42cd
+	github.com/imdario/mergo v0.3.6
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/olekukonko/tablewriter v0.0.1 // indirect
 	github.com/onsi/ginkgo v1.6.0

--- a/src/omg-cli/go.sum
+++ b/src/omg-cli/go.sum
@@ -46,6 +46,8 @@ github.com/gosuri/uilive v0.0.0-20170323041506-ac356e6e42cd h1:1e+0Z+T4t1mKL5xxv
 github.com/gosuri/uilive v0.0.0-20170323041506-ac356e6e42cd/go.mod h1:qkLSc0A5EXSP6B04TrN4oQoxqFI7A8XvoXSlJi8cwk8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
+github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/src/omg-cli/omg/tiles/ert/configuration.go
+++ b/src/omg-cli/omg/tiles/ert/configuration.go
@@ -22,6 +22,8 @@ import (
 	"omg-cli/config"
 	"omg-cli/omg/tiles"
 	"omg-cli/ops_manager"
+
+	"github.com/imdario/mergo"
 )
 
 type Properties struct {
@@ -41,39 +43,39 @@ type Properties struct {
 	// UAA
 	ServiceProviderCredentials tiles.OldCertificateValue `json:".uaa.service_provider_key_credentials"`
 
-	UaaDbChoice   tiles.Value        `json:".properties.uaa_database"`
-	UaaDbIp       tiles.Value        `json:".properties.uaa_database.external.host"`
-	UaaDbPort     tiles.IntegerValue `json:".properties.uaa_database.external.port"`
-	UaaDbUsername tiles.Value        `json:".properties.uaa_database.external.uaa_username"`
-	UaaDbPassword tiles.SecretValue  `json:".properties.uaa_database.external.uaa_password"`
+	UaaDbChoice   *tiles.Value        `json:".properties.uaa_database,omitempty"`
+	UaaDbIp       *tiles.Value        `json:".properties.uaa_database.external.host,omitempty"`
+	UaaDbPort     *tiles.IntegerValue `json:".properties.uaa_database.external.port,omitempty"`
+	UaaDbUsername *tiles.Value        `json:".properties.uaa_database.external.uaa_username,omitempty"`
+	UaaDbPassword *tiles.SecretValue  `json:".properties.uaa_database.external.uaa_password,omitempty"`
 
 	// Databases
-	ErtDbChoice tiles.Value        `json:".properties.system_database"`
-	ErtDbIp     tiles.Value        `json:".properties.system_database.external.host"`
-	ErtDbPort   tiles.IntegerValue `json:".properties.system_database.external.port"`
+	ErtDbChoice tiles.Value         `json:".properties.system_database"`
+	ErtDbIp     *tiles.Value        `json:".properties.system_database.external.host,omitempty"`
+	ErtDbPort   *tiles.IntegerValue `json:".properties.system_database.external.port,omitempty"`
 
-	ErtDbAppUsageUsername            tiles.Value       `json:".properties.system_database.external.app_usage_service_username"`
-	ErtDbAppUsagePassword            tiles.SecretValue `json:".properties.system_database.external.app_usage_service_password"`
-	ErtDbAutoscaleUsername           tiles.Value       `json:".properties.system_database.external.autoscale_username"`
-	ErtDbAutoscalePassword           tiles.SecretValue `json:".properties.system_database.external.autoscale_password"`
-	ErtDbCloudControllerUsername     tiles.Value       `json:".properties.system_database.external.ccdb_username"`
-	ErtDbCloudControllerPassword     tiles.SecretValue `json:".properties.system_database.external.ccdb_password"`
-	ErtDbDiegoUsername               tiles.Value       `json:".properties.system_database.external.diego_username"`
-	ErtDbDiegoPassword               tiles.SecretValue `json:".properties.system_database.external.diego_password"`
-	ErtDbLocketUsername              tiles.Value       `json:".properties.system_database.external.locket_username"`
-	ErtDbLocketPassword              tiles.SecretValue `json:".properties.system_database.external.locket_password"`
-	ErtDbNetworkPolicyServerUsername tiles.Value       `json:".properties.system_database.external.networkpolicyserver_username"`
-	ErtDbNetworkPolicyServerPassword tiles.SecretValue `json:".properties.system_database.external.networkpolicyserver_password"`
-	ErtDbNfsUsername                 tiles.Value       `json:".properties.system_database.external.nfsvolume_username"`
-	ErtDbNfsPassword                 tiles.SecretValue `json:".properties.system_database.external.nfsvolume_password"`
-	ErtDbNotificationsUsername       tiles.Value       `json:".properties.system_database.external.notifications_username"`
-	ErtDbNotificationsPassword       tiles.SecretValue `json:".properties.system_database.external.notifications_password"`
-	ErtDbAccountUsername             tiles.Value       `json:".properties.system_database.external.account_username"`
-	ErtDbAccountPassword             tiles.SecretValue `json:".properties.system_database.external.account_password"`
-	ErtDbRoutingUsername             tiles.Value       `json:".properties.system_database.external.routing_username"`
-	ErtDbRoutingPassword             tiles.SecretValue `json:".properties.system_database.external.routing_password"`
-	ErtDbSilkUsername                tiles.Value       `json:".properties.system_database.external.silk_username"`
-	ErtDbSilkPassword                tiles.SecretValue `json:".properties.system_database.external.silk_password"`
+	ErtDbAppUsageUsername            *tiles.Value       `json:".properties.system_database.external.app_usage_service_username,omitempty"`
+	ErtDbAppUsagePassword            *tiles.SecretValue `json:".properties.system_database.external.app_usage_service_password,omitempty"`
+	ErtDbAutoscaleUsername           *tiles.Value       `json:".properties.system_database.external.autoscale_username,omitempty"`
+	ErtDbAutoscalePassword           *tiles.SecretValue `json:".properties.system_database.external.autoscale_password,omitempty"`
+	ErtDbCloudControllerUsername     *tiles.Value       `json:".properties.system_database.external.ccdb_username,omitempty"`
+	ErtDbCloudControllerPassword     *tiles.SecretValue `json:".properties.system_database.external.ccdb_password,omitempty"`
+	ErtDbDiegoUsername               *tiles.Value       `json:".properties.system_database.external.diego_username,omitempty"`
+	ErtDbDiegoPassword               *tiles.SecretValue `json:".properties.system_database.external.diego_password,omitempty"`
+	ErtDbLocketUsername              *tiles.Value       `json:".properties.system_database.external.locket_username,omitempty"`
+	ErtDbLocketPassword              *tiles.SecretValue `json:".properties.system_database.external.locket_password,omitempty"`
+	ErtDbNetworkPolicyServerUsername *tiles.Value       `json:".properties.system_database.external.networkpolicyserver_username,omitempty"`
+	ErtDbNetworkPolicyServerPassword *tiles.SecretValue `json:".properties.system_database.external.networkpolicyserver_password,omitempty"`
+	ErtDbNfsUsername                 *tiles.Value       `json:".properties.system_database.external.nfsvolume_username,omitempty"`
+	ErtDbNfsPassword                 *tiles.SecretValue `json:".properties.system_database.external.nfsvolume_password,omitempty"`
+	ErtDbNotificationsUsername       *tiles.Value       `json:".properties.system_database.external.notifications_username,omitempty"`
+	ErtDbNotificationsPassword       *tiles.SecretValue `json:".properties.system_database.external.notifications_password,omitempty"`
+	ErtDbAccountUsername             *tiles.Value       `json:".properties.system_database.external.account_username,omitempty"`
+	ErtDbAccountPassword             *tiles.SecretValue `json:".properties.system_database.external.account_password,omitempty"`
+	ErtDbRoutingUsername             *tiles.Value       `json:".properties.system_database.external.routing_username,omitempty"`
+	ErtDbRoutingPassword             *tiles.SecretValue `json:".properties.system_database.external.routing_password,omitempty"`
+	ErtDbSilkUsername                *tiles.Value       `json:".properties.system_database.external.silk_username,omitempty"`
+	ErtDbSilkPassword                *tiles.SecretValue `json:".properties.system_database.external.silk_password,omitempty"`
 
 	// MySQL
 	MySqlMonitorRecipientEmail tiles.Value `json:".mysql_monitor.recipient_email"`
@@ -155,39 +157,48 @@ func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_
 		SecurityAcknowledgement:    tiles.Value{"X"},
 		ServiceProviderCredentials: tiles.OldCertificateValue{tiles.Certificate{cfg.SslCertificate, cfg.SslPrivateKey}},
 
-		UaaDbChoice:   tiles.Value{"external"},
-		UaaDbIp:       tiles.Value{cfg.ExternalSqlIp},
-		UaaDbPort:     tiles.IntegerValue{cfg.ExternalSqlPort},
-		UaaDbUsername: tiles.Value{cfg.ERTSqlUsername},
-		UaaDbPassword: tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-
-		ErtDbChoice:                      tiles.Value{"external"},
-		ErtDbIp:                          tiles.Value{cfg.ExternalSqlIp},
-		ErtDbPort:                        tiles.IntegerValue{cfg.ExternalSqlPort},
-		ErtDbAppUsageUsername:            tiles.Value{cfg.ERTSqlUsername},
-		ErtDbAppUsagePassword:            tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbAutoscaleUsername:           tiles.Value{cfg.ERTSqlUsername},
-		ErtDbAutoscalePassword:           tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbCloudControllerUsername:     tiles.Value{cfg.ERTSqlUsername},
-		ErtDbCloudControllerPassword:     tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbDiegoUsername:               tiles.Value{cfg.ERTSqlUsername},
-		ErtDbDiegoPassword:               tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbLocketUsername:              tiles.Value{cfg.ERTSqlUsername},
-		ErtDbLocketPassword:              tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbNetworkPolicyServerUsername: tiles.Value{cfg.ERTSqlUsername},
-		ErtDbNetworkPolicyServerPassword: tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbNfsUsername:                 tiles.Value{cfg.ERTSqlUsername},
-		ErtDbNfsPassword:                 tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbNotificationsUsername:       tiles.Value{cfg.ERTSqlUsername},
-		ErtDbNotificationsPassword:       tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbAccountUsername:             tiles.Value{cfg.ERTSqlUsername},
-		ErtDbAccountPassword:             tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbRoutingUsername:             tiles.Value{cfg.ERTSqlUsername},
-		ErtDbRoutingPassword:             tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-		ErtDbSilkUsername:                tiles.Value{cfg.ERTSqlUsername},
-		ErtDbSilkPassword:                tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
-
 		MySqlMonitorRecipientEmail: tiles.Value{"admin@example.org"},
+	}
+
+	if envConfig.SmallFootprint {
+		mergo.Merge(&properties, Properties{
+			//			UaaDbChoice: tiles.Value{"external"},
+			ErtDbChoice: tiles.Value{"internal_pxc"},
+		})
+	} else {
+		mergo.Merge(&properties, Properties{
+			UaaDbChoice:   &tiles.Value{"external"},
+			UaaDbIp:       &tiles.Value{cfg.ExternalSqlIp},
+			UaaDbPort:     &tiles.IntegerValue{cfg.ExternalSqlPort},
+			UaaDbUsername: &tiles.Value{cfg.ERTSqlUsername},
+			UaaDbPassword: &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+
+			ErtDbChoice:                      tiles.Value{"external"},
+			ErtDbIp:                          &tiles.Value{cfg.ExternalSqlIp},
+			ErtDbPort:                        &tiles.IntegerValue{cfg.ExternalSqlPort},
+			ErtDbAppUsageUsername:            &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbAppUsagePassword:            &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbAutoscaleUsername:           &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbAutoscalePassword:           &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbCloudControllerUsername:     &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbCloudControllerPassword:     &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbDiegoUsername:               &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbDiegoPassword:               &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbLocketUsername:              &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbLocketPassword:              &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbNetworkPolicyServerUsername: &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbNetworkPolicyServerPassword: &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbNfsUsername:                 &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbNfsPassword:                 &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbNotificationsUsername:       &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbNotificationsPassword:       &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbAccountUsername:             &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbAccountPassword:             &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbRoutingUsername:             &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbRoutingPassword:             &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+			ErtDbSilkUsername:                &tiles.Value{cfg.ERTSqlUsername},
+			ErtDbSilkPassword:                &tiles.SecretValue{tiles.Secret{cfg.ERTSqlPassword}},
+		})
 	}
 
 	propertiesBytes, err := json.Marshal(&properties)

--- a/src/omg-cli/omg/tiles/gcp_director/configuration.go
+++ b/src/omg-cli/omg/tiles/gcp_director/configuration.go
@@ -43,13 +43,15 @@ director-configuration:
     bucket_name: {{.DirectorBucket}}
     service_account_key: '{{.OpsManagerServiceAccountKey}}'
     storage_class: MULTI_REGIONAL
-  database_type: external
+  database_type: {{.DatabaseType}}
+{{if eq .DatabaseType "external"}}
   external_database_options:
     host: {{.ExternalSqlIp}}
     database: {{.OpsManagerSqlDbName}}
     user: {{.OpsManagerSqlUsername}}
     password: {{.OpsManagerSqlPassword}}
     port: {{.ExternalSqlPort}}
+{{end}}
 iaas-configuration:
   project: {{.ProjectName}}
   auth_json: '{{.OpsManagerServiceAccountKey}}'
@@ -135,15 +137,18 @@ func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_
 		config.Config
 		CompilationInstances    int
 		CompilationInstanceType string
+		DatabaseType            string
 	}{
 		Config: *cfg,
 	}
 	if envConfig.SmallFootprint {
 		dc.CompilationInstances = 1
 		dc.CompilationInstanceType = "medium.mem"
+		dc.DatabaseType = "internal"
 	} else {
 		dc.CompilationInstances = 4
 		dc.CompilationInstanceType = "large.cpu"
+		dc.DatabaseType = "external"
 	}
 	// Healthwatch includes a C++ package that requires a large
 	// ephemeral disk for compilation.

--- a/src/omg-tf/external_database/outputs.tf
+++ b/src/omg-tf/external_database/outputs.tf
@@ -3,31 +3,31 @@ output "sql_db_port" {
 }
 
 output "sql_db_ip" {
-  value = "${google_sql_database_instance.master.0.ip_address.0.ip_address}"
+  value = "${ join(" ", google_sql_database_instance.master.*.ip_address.0.ip_address) }"
 }
 
 output "opsman_sql_db_name" {
-  value = "${google_sql_database.opsman.0.name}"
+  value = "${ join(" ", google_sql_database.opsman.*.name) }"
 }
 
 output "opsman_sql_username" {
-  value = "${random_id.opsman_db_username.0.b64}"
+  value = "${ join(" ", random_id.opsman_db_username.*.b64) }"
 }
 
 output "opsman_sql_password" {
   sensitive = true
-  value = "${random_id.opsman_db_password.0.b64}"
+  value = "${ join(" ", random_id.opsman_db_password.*.b64) }"
 }
 
 output "ert_sql_username" {
-  value = "${random_id.ert_db_username.0.b64}"
+  value = "${ join(" ", random_id.ert_db_username.*.b64) }"
 }
 
 output "ert_sql_password" {
   sensitive = true
-  value = "${random_id.ert_db_password.0.b64}"
+  value = "${ join(" ", random_id.ert_db_password.*.b64) }"
 }
 
 output "ip" {
-  value = "${google_sql_database_instance.master.0.ip_address.0.ip_address}"
+  value = "${ join(" ", google_sql_database_instance.master.*.ip_address.0.ip_address) }"
 }

--- a/src/omg-tf/init.sh
+++ b/src/omg-tf/init.sh
@@ -65,11 +65,13 @@ nat_instance_count=3
 nat_machine_type="n1-standard-1"
 opsman_machine_type="n1-standard-2"
 jumpbox_machine_type="n1-standard-1"
+external_database="true"
 if [ "${SMALL_FOOTPRINT}" == "true" ]; then
   nat_instance_count=1
   nat_machine_type="g1-small"
   opsman_machine_type="n1-standard-1"
   jumpbox_machine_type="g1-small"
+  external_database="false"
 fi
 
 set -e
@@ -110,7 +112,7 @@ ops_manager_password = "${OPSMAN_ADMIN_PASSWORD:-}"
 ops_manager_skip_ssl_verify = "true"
 region = "${REGION}"
 zones = ["${ZONE1}", "${ZONE2}", "${ZONE3}"]
-external_database = "true"
+external_database = "${external_database}"
 
 ssl_cert = <<SSL_CERT
 $(cat keys/server.crt)


### PR DESCRIPTION
This PR configures OpsMan and PAS to use their internal database. The main reason for this change is working around a known credhub google cloud sql incompatibility (full details at the end of the PR).

A nice side effect of this change is that it further reduces the costs of running a small footprint deployment.

Details on credhub issue with the PAS upgrade 2.3.x:
- Small footprint PAS 2.3.3 credhub database issue:
 - unable to use external db because of [this issue](https://issuetracker.google.com/issues/112084548?pli=1)
 - mixing internal (for credhub) and external on Databases tab does no longer work because of the [pxc_enabled property](https://gist.github.com/rkoster/5a1e6371b71a3b21eb7dd2ec414a04e8#file-small-runtime-metadata-yml-L2042) which only gets set when using internal db.
- Normal PAS 2.3.3 works
 -  because credhub uses a seperate instance which [defaults to zero instances](https://gist.github.com/rkoster/85fadb932a82fd50fdc9c3b7bc78c6c8#file-full-runtime-metadata-yml-L6405)

The above was not an issue in PAS 2.1.17 because there was no option to disable the mysql process:
- PAS 2.1.7 uses v36.11.0: [msyql job monit file](https://github.com/cloudfoundry/cf-mysql-release/blob/v36.11.0/jobs/mysql/monit)
- PAS 2.3.3 uses v36.15.0  [msyql job monit file](https://github.com/cloudfoundry/cf-mysql-release/blob/v36.15.0/jobs/mysql/monit) which has the `cf_mysql_enabled` property