### PR TITLE
Update terraform-google-provider

### DIFF
--- a/src/omg-tf/jumpbox.tf
+++ b/src/omg-tf/jumpbox.tf
@@ -2,7 +2,11 @@ resource "google_compute_instance" "jumpbox" {
   name           = "${var.env_name}-jumpbox"
   machine_type   = "${var.jumpbox_machine_type}"
   zone           = "${element(var.zones, 1)}"
-  create_timeout = 10
+
+  timeouts {
+    create = "10m"
+  }
+
   tags           = ["${var.env_name}-jumpbox-external"]
 
   boot_disk {

--- a/src/omg-tf/nat.tf
+++ b/src/omg-tf/nat.tf
@@ -2,7 +2,11 @@ resource "google_compute_instance" "nat" {
   name           = "${var.env_name}-nat-${count.index}"
   machine_type   = "${var.nat_machine_type}"
   zone           = "${element(var.zones, (count.index % length(var.zones)))}"
-  create_timeout = 10
+
+  timeouts {
+    create = "10m"
+  }
+
   tags           = ["${var.env_name}-nat-external"]
   count          = "${var.nat_instance_count}"
 

--- a/src/omg-tf/ops_manager.tf
+++ b/src/omg-tf/ops_manager.tf
@@ -15,7 +15,10 @@ resource "google_compute_firewall" "ops-manager-external" {
 resource "google_compute_image" "ops-manager-image" {
   count          = "${var.opsman_image_selflink != "" ? 0 : 1}"
   name           = "${var.env_name}-ops-manager-image"
-  create_timeout = 20
+
+  timeouts {
+    create = "20m"
+  }
 
   raw_disk {
     source = "${var.opsman_image_url}"
@@ -28,7 +31,11 @@ resource "google_compute_instance" "ops-manager-internal" {
   name           = "${var.env_name}-ops-manager"
   machine_type   = "${var.opsman_machine_type}"
   zone           = "${element(var.zones, 1)}"
-  create_timeout = 10
+
+  timeouts {
+    create = "10m"
+  }
+
   tags           = ["${var.env_name}-ops-manager", "${var.no_ip_instance_tag}"]
 
   boot_disk {
@@ -41,7 +48,7 @@ resource "google_compute_instance" "ops-manager-internal" {
 
   network_interface {
     subnetwork = "${google_compute_subnetwork.management-subnet.name}"
-    address    = "10.0.0.6"
+    network_ip = "10.0.0.6"
   }
 
   metadata = {
@@ -61,7 +68,11 @@ resource "google_compute_instance" "ops-manager-external" {
   name           = "${var.env_name}-ops-manager"
   machine_type   = "${var.opsman_machine_type}"
   zone           = "${element(var.zones, 1)}"
-  create_timeout = 10
+
+  timeouts {
+    create = "10m"
+  }
+
   tags           = ["${var.env_name}-ops-manager", "${var.env_name}-ops-manager-external"]
 
   boot_disk {
@@ -74,7 +85,7 @@ resource "google_compute_instance" "ops-manager-external" {
 
   network_interface {
     subnetwork = "${google_compute_subnetwork.management-subnet.name}"
-    address    = "10.0.0.6"
+    network_ip = "10.0.0.6"
 
     access_config {
       nat_ip = "${google_compute_address.ops-manager-external.address}"

--- a/src/omg-tf/provider.tf
+++ b/src/omg-tf/provider.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  version     = "v1.4.0"
+  version     = "v1.19.1"
 
   project     = "${var.project}"
   region      = "${var.region}"


### PR DESCRIPTION
Ran terraform plan and verified no infrastructure changes occurred.
Updated deprecated `create_timeout` and `address` fields to their
respective, preferred replacements.