### PR TITLE
Stackdrive nozzle version 2.0.1 needs stemcell ubuntu-trusty 3468

### DIFF
--- a/src/omg-cli/omg/tiles/stackdriver_nozzle/resource.go
+++ b/src/omg-cli/omg/tiles/stackdriver_nozzle/resource.go
@@ -34,11 +34,13 @@ var tile = config.Tile{
 		true,
 	},
 	&config.StemcellMetadata{
-		config.PivnetMetadata{"stemcells",
-			28004,
-			58600,
-			"160e6ebc0f34af53543803eed4b7772fb7beaaa25cb3262ab170884e06feb721"},
-		"light-bosh-stemcell-3421.36-google-kvm-ubuntu-trusty-go_agent",
+		config.PivnetMetadata{
+			"stemcells",
+			214323,
+			247292,
+			"8c6caeae37711aaf12b4fefba06c348cde5631e872e8892553ddb26514a3953a",
+		},
+		"light-bosh-stemcell-3468.78-google-kvm-ubuntu-trusty-go_agent",
 	},
 }
 


### PR DESCRIPTION
While is was testing https://github.com/cf-platform-eng/gcp-pcf-quickstart/pull/30 I noticed the stemcell dependency the stackdriver nozzle was out of date (it worked because it used the stemcell from the service broker). This PR fixes the stemcell dependency.