### PR TITLE
Use terraform gcs backend in concourse pipeline

### DIFF
--- a/ci/docker-image/Dockerfile
+++ b/ci/docker-image/Dockerfile
@@ -43,8 +43,8 @@ RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
 
 ENV PATH=$PATH:/google-cloud-sdk/bin
 
-ENV TERRAFORM_VERSION=0.11.1
-ENV TERRAFORM_SHA256SUM=4e3d5e4c6a267e31e9f95d4c1b00f5a7be5a319698f0370825b459cb786e2f35
+ENV TERRAFORM_VERSION=0.11.10
+ENV TERRAFORM_SHA256SUM=43543a0e56e31b0952ea3623521917e060f2718ab06fe2b2d506cfaa14d54527
 
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
     -O terraform.zip && \

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -88,6 +88,7 @@ jobs:
           google_project: ((google_project))
           google_json_key_data: ((google_json_key_data))
           env_file_name: ((env_file_name))
+          terraform_state_bucket: ((ci_bucket_name))
       - put: omg-env
         params:
           file: omg-env/*.tgz
@@ -135,6 +136,7 @@ jobs:
                     google_project: ((google_project))
                     google_json_key_data: ((google_json_key_data))
                     env_file_name: ((env_file_name))
+                    terraform_state_bucket: ((ci_bucket_name))
                 - *destroy_infrastructure
 
   - name: run-certification

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,7 +6,9 @@ groups:
       - prepare-project
       - generate-env
       - create-infrastructure
+      - destroy-infrastructure
       - deploy-pcf
+      - destroy-pcf
       - run-certification
       - destroy-all
       - promote-candidate-major
@@ -93,6 +95,49 @@ jobs:
         params:
           file: omg-env/*.tgz
 
+  - name: destroy-pcf
+    serial: true
+    serial_groups: [gcp-project]
+    plan:
+      - aggregate:
+          - get: omg-src-in
+            passed: [create-infrastructure]
+          - get: omg-env
+            passed: [create-infrastructure]
+          - get: ci-image
+      - do:
+        - &destroy_pcf
+          task: destroy-pcf
+          image: ci-image
+          file: omg-src-in/ci/tasks/destroy-pcf.yml
+          params:
+            google_project: ((google_project))
+            google_json_key_data: ((google_json_key_data))
+            env_file_name: ((env_file_name))
+
+  - name: destroy-infrastructure
+    serial: true
+    serial_groups: [gcp-project]
+    plan:
+      - aggregate:
+          - get: omg-src-in
+            passed: [create-infrastructure]
+          - get: omg-env
+            passed: [create-infrastructure]
+          - get: ci-image
+      - do:
+        - try:
+            *destroy_pcf
+        - &destroy_infrastructure
+          task: destroy-infrastructure
+          image: ci-image
+          file: omg-src-in/ci/tasks/destroy-infrastructure.yml
+          params:
+            google_project: ((google_project))
+            google_json_key_data: ((google_json_key_data))
+            env_file_name: ((env_file_name))
+            terraform_state_bucket: ((ci_bucket_name))
+
   - name: deploy-pcf
     serial: true
     serial_groups: [gcp-project]
@@ -113,31 +158,11 @@ jobs:
             file: omg-src-in/ci/tasks/push-tiles.yml
             params:
               env_file_name: ((env_file_name))
-            on_failure: &destroy_infrastructure
-              task: destroy-infrastructure
-              image: ci-image
-              file: omg-src-in/ci/tasks/destroy-infrastructure.yml
-              params:
-                google_project: ((google_project))
-                google_json_key_data: ((google_json_key_data))
-                env_file_name: ((env_file_name))
           - task: deploy-pcf
             image: ci-image
             file: omg-src-in/ci/tasks/deploy-pcf.yml
             params:
               env_file_name: ((env_file_name))
-            on_failure:
-              do:
-                - &destroy_pcf
-                  task: destroy-pcf
-                  image: ci-image
-                  file: omg-src-in/ci/tasks/destroy-pcf.yml
-                  params:
-                    google_project: ((google_project))
-                    google_json_key_data: ((google_json_key_data))
-                    env_file_name: ((env_file_name))
-                    terraform_state_bucket: ((ci_bucket_name))
-                - *destroy_infrastructure
 
   - name: run-certification
     serial: true
@@ -159,10 +184,6 @@ jobs:
         file: omg-src-in/ci/tasks/run-certification.yml
         params:
           env_file_name: ((env_file_name))
-        on_failure:
-          do: &destroy_all
-            - *destroy_pcf
-            - *destroy_infrastructure
 
   - name: destroy-all
     serial: true
@@ -178,9 +199,9 @@ jobs:
             get: omg-env
             resource: omg-env
           - get: ci-image
-      - do: *destroy_all
-        on_failure:
-          do: *destroy_all
+      - do:
+        - *destroy_pcf
+        - *destroy_infrastructure
 
   - name: promote-candidate-major
     serial: true

--- a/ci/tasks/create-infrastructure.sh
+++ b/ci/tasks/create-infrastructure.sh
@@ -14,15 +14,15 @@ trap save_terraform_state EXIT
 
 function rollback {
 	pushd "${release_dir}/src/omg-tf"
-		yes "yes" | terraform destroy --parallelism=100 -state=${terraform_state} -var-file=${terraform_config}
+		yes "yes" | terraform destroy --parallelism=100 -var-file=${terraform_config}
 	popd
 }
 trap rollback ERR
 
 pushd "${release_dir}/src/omg-tf"
+        configure_terraform_backend
 	terraform init
 	terraform get
-	terraform apply --auto-approve --parallelism=100 -state=${terraform_state} -var-file=${terraform_config}
-	terraform output -json -state=${terraform_state} > ${terraform_output}
+	terraform apply --auto-approve --parallelism=100 -var-file=${terraform_config}
+	terraform output -json > ${terraform_output}
 popd
-

--- a/ci/tasks/destroy-infrastructure.sh
+++ b/ci/tasks/destroy-infrastructure.sh
@@ -16,10 +16,10 @@ pushd "${release_dir}/src/omg-tf"
         configure_terraform_backend
 	terraform init
 	terraform get
-	yes "yes" | terraform destroy --parallelism=100 -var-file=${terraform_config} && exit 0
+	terraform destroy --auto-approve --parallelism=100 -var-file=${terraform_config} && exit 0
 
 	seconds=300
 	echo "terraform destroy failed, trying again in ${seconds} seconds"
 	sleep ${seconds}
-	yes "yes" | terraform destroy --parallelism=100 -var-file=${terraform_config}
+	terraform destroy --auto-approve --parallelism=100 -var-file=${terraform_config}
 popd

--- a/ci/tasks/destroy-infrastructure.sh
+++ b/ci/tasks/destroy-infrastructure.sh
@@ -13,12 +13,13 @@ popd > /dev/null
 trap save_terraform_state EXIT
 
 pushd "${release_dir}/src/omg-tf"
+        configure_terraform_backend
 	terraform init
 	terraform get
-	yes "yes" | terraform destroy --parallelism=100 -state=${terraform_state} -var-file=${terraform_config} && exit 0
+	yes "yes" | terraform destroy --parallelism=100 -var-file=${terraform_config} && exit 0
 
 	seconds=300
 	echo "terraform destroy failed, trying again in ${seconds} seconds"
 	sleep ${seconds}
-	yes "yes" | terraform destroy --parallelism=100 -state=${terraform_state} -var-file=${terraform_config}
+	yes "yes" | terraform destroy --parallelism=100 -var-file=${terraform_config}
 popd

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -102,6 +102,19 @@ generate_env_config() {
     echo "${env_config}" > "${env_dir}/config.json"
 }
 
+configure_terraform_backend() {
+    check_param "terraform_state_bucket"
+    check_param "env_file_name"
+    cat << EOF > state.tf
+terraform {
+  backend "gcs" {
+    bucket = "${terraform_state_bucket}"
+    prefix  = "terraform/${env_file_name%.*}"
+  }
+}
+EOF
+}
+
 function save_terraform_state {
 	pushd "${env_dir}"
 		tar czvf ${env_output_file} .


### PR DESCRIPTION
This PR switches to the terraform gcs backend, for storing state. This allows for a more robust pipeline. Since failed builds should be easier to cleanup.

Additionally I have removed the on_failure cleanup actions. And instead added optional cleanup jobs. For more fine grained control how to continue in the case of a failure (cleanup or rerun with new commit).

The destroy all job will still be triggered when all intermediate steps are successful. I have only tried to optimise the debug workflow for when things don't work as expected.