### PR TITLE
Remove underscores from package names

### DIFF
--- a/ci/docker-image/system_tests/container_test.go
+++ b/ci/docker-image/system_tests/container_test.go
@@ -27,13 +27,13 @@ import (
 
 var _ = Describe("Docker Image", func() {
 	commands := map[string][]string{
-		"gcloud":    []string{"--version"},
-		"gsutil":    []string{"--version"},
-		"jq":        []string{"--version"},
-		"ginkgo":    []string{"help"},
-		"go":        []string{"version"},
-		"dig":       []string{"-h"},
-		"terraform": []string{"version"},
+		"gcloud":    {"--version"},
+		"gsutil":    {"--version"},
+		"jq":        {"--version"},
+		"ginkgo":    {"help"},
+		"go":        {"version"},
+		"dig":       {"-h"},
+		"terraform": {"version"},
 	}
 
 	for executable, args := range commands {

--- a/src/omg-cli/certification/environment/opsman.go
+++ b/src/omg-cli/certification/environment/opsman.go
@@ -19,7 +19,7 @@ package environment
 import (
 	"fmt"
 
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 
 	"github.com/pivotal-cf/om/api"
 )
@@ -50,7 +50,7 @@ type TileQuery interface {
 }
 
 type liveOpsManager struct {
-	sdk *ops_manager.Sdk
+	sdk *opsman.Sdk
 }
 
 func (lom *liveOpsManager) Tile(name string) (TileQuery, error) {
@@ -82,8 +82,8 @@ func (lom *liveOpsManager) Director() DirectorProperties {
 
 type liveTileQuery struct {
 	name  string
-	props *ops_manager.ProductProperties
-	sdk   *ops_manager.Sdk
+	props *opsman.ProductProperties
+	sdk   *opsman.Sdk
 }
 
 func (ltq *liveTileQuery) Property(name string) api.ResponseProperty {

--- a/src/omg-cli/certification/environment/opsman.go
+++ b/src/omg-cli/certification/environment/opsman.go
@@ -56,7 +56,7 @@ type liveOpsManager struct {
 func (lom *liveOpsManager) Tile(name string) (TileQuery, error) {
 	props, err := lom.sdk.GetProduct(name)
 	if err != nil {
-		return nil, fmt.Errorf("getting product propeties: %v", err)
+		return nil, fmt.Errorf("getting product properties: %v", err)
 	}
 
 	return &liveTileQuery{name, props, lom.sdk}, nil

--- a/src/omg-cli/certification/environment/target.go
+++ b/src/omg-cli/certification/environment/target.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 
 	"omg-cli/config"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 
 	"github.com/onsi/ginkgo"
 )
@@ -68,7 +68,7 @@ type liveTarget struct {
 
 func (lt *liveTarget) OpsManager() OpsManagerQuery {
 	logger := log.New(os.Stdout, "TODO(jrjohnson): test logger", 0)
-	omSdk, err := ops_manager.NewSdk(fmt.Sprintf("https://%s", lt.cfg.OpsManagerHostname), lt.cfg.OpsManager, logger)
+	omSdk, err := opsman.NewSdk(fmt.Sprintf("https://%s", lt.cfg.OpsManagerHostname), lt.cfg.OpsManager, logger)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("creating ops manager sdk: %v", err))
 	}

--- a/src/omg-cli/omg/commands/commands.go
+++ b/src/omg-cli/omg/commands/commands.go
@@ -23,11 +23,11 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/tiles"
+	"omg-cli/omg/tiles/director"
 	"omg-cli/omg/tiles/ert"
-	"omg-cli/omg/tiles/gcp_director"
 	"omg-cli/omg/tiles/healthwatch"
-	"omg-cli/omg/tiles/service_broker"
-	"omg-cli/omg/tiles/stackdriver_nozzle"
+	"omg-cli/omg/tiles/servicebroker"
+	"omg-cli/omg/tiles/stackdrivernozzle"
 
 	"github.com/alecthomas/kingpin"
 )
@@ -60,10 +60,10 @@ func Configure(logger *log.Logger, app *kingpin.Application) {
 
 func selectedTiles(logger *log.Logger, config *config.EnvConfig) []tiles.TileInstaller {
 	result := []tiles.TileInstaller{
-		&gcp_director.Tile{},
+		&director.Tile{},
 		&ert.Tile{},
-		&stackdriver_nozzle.Tile{Logger: logger},
-		&service_broker.Tile{},
+		&stackdrivernozzle.Tile{Logger: logger},
+		&servicebroker.Tile{},
 	}
 	if config.IncludeHealthwatch {
 		result = append(result, &healthwatch.Tile{})

--- a/src/omg-cli/omg/commands/delete_installation.go
+++ b/src/omg-cli/omg/commands/delete_installation.go
@@ -22,7 +22,7 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/setup"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 
 	"github.com/alecthomas/kingpin"
 )
@@ -51,7 +51,7 @@ func (cmd *DeleteInstallationCommand) run(c *kingpin.ParseContext) error {
 		return err
 	}
 
-	omSdk, err := ops_manager.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
+	omSdk, err := opsman.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
 	if err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/commands/deploy.go
+++ b/src/omg-cli/omg/commands/deploy.go
@@ -22,7 +22,7 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/setup"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 
 	"github.com/alecthomas/kingpin"
 )
@@ -53,7 +53,7 @@ func (cmd *DeployCommand) run(c *kingpin.ParseContext) error {
 		return err
 	}
 
-	omSdk, err := ops_manager.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
+	omSdk, err := opsman.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
 	if err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/commands/director_ssh.go
+++ b/src/omg-cli/omg/commands/director_ssh.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 
 	"omg-cli/config"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 	"omg-cli/version"
 
 	"github.com/alecthomas/kingpin"
@@ -56,7 +56,7 @@ func (cmd *DirectorSSHCommand) run(c *kingpin.ParseContext) error {
 		return err
 	}
 
-	omSdk, err := ops_manager.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
+	omSdk, err := opsman.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
 	if err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/commands/get_credential.go
+++ b/src/omg-cli/omg/commands/get_credential.go
@@ -21,7 +21,7 @@ import (
 	"log"
 
 	"omg-cli/config"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 
 	"github.com/alecthomas/kingpin"
 )
@@ -50,7 +50,7 @@ func (cmd *GetCredentialCommand) run(c *kingpin.ParseContext) error {
 		return err
 	}
 
-	omSdk, err := ops_manager.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
+	omSdk, err := opsman.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
 	if err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/commands/push_tiles.go
+++ b/src/omg-cli/omg/commands/push_tiles.go
@@ -22,7 +22,7 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/setup"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 	"omg-cli/pivnet"
 
 	"github.com/alecthomas/kingpin"
@@ -54,7 +54,7 @@ func (cmd *PushTilesCommand) run(c *kingpin.ParseContext) error {
 		return err
 	}
 
-	omSdk, err := ops_manager.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
+	omSdk, err := opsman.NewSdk(fmt.Sprintf("https://%s", cfg.OpsManagerHostname), cfg.OpsManager, cmd.logger)
 	if err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/setup/opsman.go
+++ b/src/omg-cli/omg/setup/opsman.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"omg-cli/config"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 	"omg-cli/pivnet"
 )
 
@@ -34,7 +34,7 @@ import (
 type OpsManager struct {
 	cfg       *config.Config
 	envCfg    *config.EnvConfig
-	om        *ops_manager.Sdk
+	om        *opsman.Sdk
 	pivnet    *pivnet.Sdk
 	logger    *log.Logger
 	tiles     []tiles.TileInstaller
@@ -42,7 +42,7 @@ type OpsManager struct {
 }
 
 // NewOpsManager creates a new OpsManager for setup purposes.
-func NewOpsManager(cfg *config.Config, envCfg *config.EnvConfig, omSdk *ops_manager.Sdk, pivnetSdk *pivnet.Sdk, logger *log.Logger, tiles []tiles.TileInstaller, tileCache *pivnet.TileCache) *OpsManager {
+func NewOpsManager(cfg *config.Config, envCfg *config.EnvConfig, omSdk *opsman.Sdk, pivnetSdk *pivnet.Sdk, logger *log.Logger, tiles []tiles.TileInstaller, tileCache *pivnet.TileCache) *OpsManager {
 	return &OpsManager{cfg, envCfg, omSdk, pivnetSdk, logger, tiles, tileCache}
 }
 

--- a/src/omg-cli/omg/setup/project_test.go
+++ b/src/omg-cli/omg/setup/project_test.go
@@ -65,7 +65,7 @@ var _ = Describe("GcpProject", func() {
 			quotaErrors, satisfied, err := project.ValidateQuotas()
 			Expect(err).To(Equal(ErrUnsatisfiedQuota))
 			Expect(quotaErrors).ToNot(BeNil())
-			Expect(quotaErrors).To(ContainElement(quotaError{Quota: quotaRequirement, Region: "global"}))
+			Expect(quotaErrors).To(ContainElement(QuotaError{Quota: quotaRequirement, Region: "global"}))
 			Expect(satisfied).To(BeEmpty())
 		})
 
@@ -103,7 +103,7 @@ var _ = Describe("GcpProject", func() {
 
 			errors, satisfied, err := project.ValidateQuotas()
 			Expect(err).To(Equal(ErrUnsatisfiedQuota))
-			Expect(errors).To(ContainElement(quotaError{Quota: quotaRequirement, Actual: 10.0, Region: "us-east1"}))
+			Expect(errors).To(ContainElement(QuotaError{Quota: quotaRequirement, Actual: 10.0, Region: "us-east1"}))
 			Expect(satisfied).To(BeEmpty())
 		})
 	})

--- a/src/omg-cli/omg/tiles/director/configuration.go
+++ b/src/omg-cli/omg/tiles/director/configuration.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package gcp_director
+package director
 
 import (
 	"bytes"
@@ -24,7 +24,7 @@ import (
 	"text/template"
 
 	"omg-cli/config"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 )
 
 const directorTemplateYAML = `---
@@ -132,7 +132,7 @@ func reservedIPs(cidr string) string {
 }
 
 // Configure satisfies TileInstaller interface.
-func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_manager.Sdk) error {
+func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *opsman.Sdk) error {
 	dc := struct {
 		config.Config
 		CompilationInstances    int

--- a/src/omg-cli/omg/tiles/director/resource.go
+++ b/src/omg-cli/omg/tiles/director/resource.go
@@ -14,41 +14,20 @@
  * limitations under the License.
  */
 
-package stackdriver_nozzle
+package director
 
 import (
-	"log"
-
 	"omg-cli/config"
 )
 
 var tile = config.Tile{
-	Pivnet: config.PivnetMetadata{
-		Name:      "gcp-stackdriver-nozzle",
-		ReleaseID: 53596,
-		FileID:    89124,
-		Sha256:    "80e137622ca76868693b406114a2c7c1fdf6ce5db91c77a8d848d558d288fe5c",
-	},
 	Product: config.OpsManagerMetadata{
-		Name:         "stackdriver-nozzle",
-		Version:      "2.0.1",
-		DependsOnPAS: true,
-	},
-	Stemcell: &config.StemcellMetadata{
-		PivnetMetadata: config.PivnetMetadata{
-			Name:      "stemcells",
-			ReleaseID: 214323,
-			FileID:    247292,
-			Sha256:    "8c6caeae37711aaf12b4fefba06c348cde5631e872e8892553ddb26514a3953a",
-		},
-		StemcellName: "light-bosh-stemcell-3468.78-google-kvm-ubuntu-trusty-go_agent",
+		Name: "BOSH Director",
 	},
 }
 
-// Tile is the tile for the Stackdriver Nozzle.
-type Tile struct {
-	Logger *log.Logger
-}
+// Tile is the tile for the BOSH Director.
+type Tile struct{}
 
 // Definition satisfies TileInstaller interface.
 func (*Tile) Definition(*config.EnvConfig) config.Tile {
@@ -57,5 +36,5 @@ func (*Tile) Definition(*config.EnvConfig) config.Tile {
 
 // BuiltIn satisfies TileInstaller interface.
 func (*Tile) BuiltIn() bool {
-	return false
+	return true
 }

--- a/src/omg-cli/omg/tiles/ert/configuration.go
+++ b/src/omg-cli/omg/tiles/ert/configuration.go
@@ -22,7 +22,7 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/tiles"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 
 	"github.com/imdario/mergo"
 )
@@ -121,7 +121,7 @@ type smallFootprintResources struct {
 }
 
 // Configure satisfies TileInstaller interface.
-func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_manager.Sdk) error {
+func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *opsman.Sdk) error {
 	if err := om.StageProduct(product); err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/tiles/healthwatch/configuration.go
+++ b/src/omg-cli/omg/tiles/healthwatch/configuration.go
@@ -22,7 +22,7 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/tiles"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 )
 
 type properties struct {
@@ -35,7 +35,7 @@ type resources struct {
 }
 
 // Configure satisfies TileInstaller interface.
-func (t *Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_manager.Sdk) error {
+func (t *Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *opsman.Sdk) error {
 	if err := om.StageProduct(tile.Product); err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/tiles/service.go
+++ b/src/omg-cli/omg/tiles/service.go
@@ -18,7 +18,7 @@ package tiles
 
 import (
 	"omg-cli/config"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 )
 
 // TileInstaller defines and configures an Ops Manager Tile.
@@ -28,7 +28,7 @@ type TileInstaller interface {
 	Definition(envConfig *config.EnvConfig) config.Tile
 
 	// Configure applies configuration to a tile via the Ops Manager SDK.
-	Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_manager.Sdk) error
+	Configure(envConfig *config.EnvConfig, cfg *config.Config, om *opsman.Sdk) error
 
 	// BuiltIn is true if a tile is built in to the Ops Manager.
 	BuiltIn() bool

--- a/src/omg-cli/omg/tiles/servicebroker/configuration.go
+++ b/src/omg-cli/omg/tiles/servicebroker/configuration.go
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package service_broker
+package servicebroker
 
 import (
 	"encoding/json"
 
 	"omg-cli/config"
 	"omg-cli/omg/tiles"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 )
 
 type properties struct {
@@ -32,7 +32,7 @@ type properties struct {
 }
 
 // Configure satisfies TileInstaller interface.
-func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_manager.Sdk) error {
+func (*Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *opsman.Sdk) error {
 	if err := om.StageProduct(tile.Product); err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/tiles/servicebroker/resource.go
+++ b/src/omg-cli/omg/tiles/servicebroker/resource.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package service_broker
+package servicebroker
 
 import (
 	"omg-cli/config"

--- a/src/omg-cli/omg/tiles/stackdrivernozzle/configuration.go
+++ b/src/omg-cli/omg/tiles/stackdrivernozzle/configuration.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package stackdriver_nozzle
+package stackdrivernozzle
 
 import (
 	"encoding/json"
@@ -22,7 +22,7 @@ import (
 
 	"omg-cli/config"
 	"omg-cli/omg/tiles"
-	"omg-cli/ops_manager"
+	"omg-cli/opsman"
 )
 
 const (
@@ -41,7 +41,7 @@ type resources struct {
 }
 
 // Configure satisfies TileInstaller interface.
-func (t *Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *ops_manager.Sdk) error {
+func (t *Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *opsman.Sdk) error {
 	if err := om.StageProduct(tile.Product); err != nil {
 		return err
 	}

--- a/src/omg-cli/omg/tiles/stackdrivernozzle/configuration.go
+++ b/src/omg-cli/omg/tiles/stackdrivernozzle/configuration.go
@@ -69,16 +69,16 @@ func (t *Tile) Configure(envConfig *config.EnvConfig, cfg *config.Config, om *op
 	if envConfig.SmallFootprint {
 		vmType = "micro"
 	}
-	resoruces := resources{
+	resources := resources{
 		StackdriverNozzle: tiles.Resource{
 			InternetConnected: false,
 			VMTypeID:          vmType,
 		},
 	}
-	resorucesBytes, err := json.Marshal(&resoruces)
+	resourcesBytes, err := json.Marshal(&resources)
 	if err != nil {
 		return err
 	}
 
-	return om.ConfigureProduct(tile.Product.Name, string(networkBytes), string(propertiesBytes), string(resorucesBytes))
+	return om.ConfigureProduct(tile.Product.Name, string(networkBytes), string(propertiesBytes), string(resourcesBytes))
 }

--- a/src/omg-cli/omg/tiles/stackdrivernozzle/resource.go
+++ b/src/omg-cli/omg/tiles/stackdrivernozzle/resource.go
@@ -14,20 +14,41 @@
  * limitations under the License.
  */
 
-package gcp_director
+package stackdrivernozzle
 
 import (
+	"log"
+
 	"omg-cli/config"
 )
 
 var tile = config.Tile{
+	Pivnet: config.PivnetMetadata{
+		Name:      "gcp-stackdriver-nozzle",
+		ReleaseID: 53596,
+		FileID:    89124,
+		Sha256:    "80e137622ca76868693b406114a2c7c1fdf6ce5db91c77a8d848d558d288fe5c",
+	},
 	Product: config.OpsManagerMetadata{
-		Name: "BOSH Director",
+		Name:         "stackdriver-nozzle",
+		Version:      "2.0.1",
+		DependsOnPAS: true,
+	},
+	Stemcell: &config.StemcellMetadata{
+		PivnetMetadata: config.PivnetMetadata{
+			Name:      "stemcells",
+			ReleaseID: 214323,
+			FileID:    247292,
+			Sha256:    "8c6caeae37711aaf12b4fefba06c348cde5631e872e8892553ddb26514a3953a",
+		},
+		StemcellName: "light-bosh-stemcell-3468.78-google-kvm-ubuntu-trusty-go_agent",
 	},
 }
 
-// Tile is the tile for the BOSH Director.
-type Tile struct{}
+// Tile is the tile for the Stackdriver Nozzle.
+type Tile struct {
+	Logger *log.Logger
+}
 
 // Definition satisfies TileInstaller interface.
 func (*Tile) Definition(*config.EnvConfig) config.Tile {
@@ -36,5 +57,5 @@ func (*Tile) Definition(*config.EnvConfig) config.Tile {
 
 // BuiltIn satisfies TileInstaller interface.
 func (*Tile) BuiltIn() bool {
-	return true
+	return false
 }

--- a/src/omg-cli/opsman/internal_types.go
+++ b/src/omg-cli/opsman/internal_types.go
@@ -1,4 +1,4 @@
-package ops_manager
+package opsman
 
 /*
  * Copyright 2017 Google Inc.

--- a/src/omg-cli/opsman/public_types.go
+++ b/src/omg-cli/opsman/public_types.go
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-// This file contains types used in responses from the ops_manager.Sdk
+// This file contains types used in responses from the opsman.Sdk
 
-package ops_manager
+package opsman
 
 import "github.com/pivotal-cf/om/api"
 

--- a/src/omg-cli/opsman/sdk.go
+++ b/src/omg-cli/opsman/sdk.go
@@ -364,7 +364,7 @@ func (om *Sdk) getCredential(path string) (*SimpleCredential, error) {
 	}
 
 	if resp.Credential.Value.Password == "" || resp.Credential.Value.Identity == "" {
-		return nil, fmt.Errorf("recieved an empty credential: %s", string(body))
+		return nil, fmt.Errorf("received an empty credential: %s", string(body))
 	}
 
 	return &resp.Credential.Value, nil

--- a/src/omg-cli/opsman/sdk.go
+++ b/src/omg-cli/opsman/sdk.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ops_manager
+package opsman
 
 import (
 	"bytes"

--- a/src/omg-cli/pivnet/sdk.go
+++ b/src/omg-cli/pivnet/sdk.go
@@ -70,7 +70,7 @@ func (s *Sdk) checkCredentials() error {
 }
 
 // DownloadTile retrieves a given productSlug, releaseId, and fileId from PivNet
-// If a os.File is return it is guarenteed to match the fileSha256
+// If a os.File is return it is guaranteed to match the fileSha256
 // If an error is returned no os.File will be returned
 //
 // Caller is responsible for deleting the os.File


### PR DESCRIPTION
See https://blog.golang.org/package-names

Changes are:
```
gcp_director -> director
service_broker -> servicebroker
stackdriver_nozzle -> strackdrivernozzle
ops_manager -> opsman
```

Also any files named `ops_manager.go` were updated to `opsman.go` for
consistency.

Also, I fixed a bad refactor which was breaking project_test.go