### PR TITLE
Add warning about OS Login

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -16,6 +16,7 @@ Follow this guide to prepare you Google Cloud Project and deployment machine.
    - If deploying Elastic Runtime:
      - Persistent Disk Standard (GB) (in desired region): 10,000 GB
      - CPUs (in desired region): 200
+1. Verify OS Login is NOT enabled in your project's Compute Engine project wide metadata. The quickstart relies on SSH keys from instance metadata during the installation process, and [enabling OS Login will disable SSH keys from instance metadata](https://cloud.google.com/compute/docs/instances/managing-instance-access#enable_oslogin). Ensure the `enable-oslogin` key is either not set or set to `FALSE` in [the Compute Engine project wide metadata](https://pantheon.corp.google.com/compute/metadata). (Running the script `./util/disable-os-login.sh` will do this for you)
 
 ## Setting up your Deployment Machine
 

--- a/util/disable-os-login.sh
+++ b/util/disable-os-login.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+which gcloud &>/dev/null || (echo error: gcloud is not on your PATH. Install the gcloud cli to continue; echo https://cloud.google.com/sdk/gcloud/; exit 1)
+
+project=$(gcloud config list 2>/dev/null)
+if [ $? -ne 0 ]; then
+    echo error: cannot read gcloud config
+    exit 1
+fi
+
+project=$(echo ${project} | grep -o -E 'project = .*' | sed 's/project = //')
+
+echo The following project will be used to disable OS Login:
+echo ${project}
+read -n 1 -s -r -p "Press any key to continue, or ^C to cancel"
+echo
+
+set -x
+gcloud compute project-info add-metadata --metadata enable-oslogin=FALSE
+


### PR DESCRIPTION
OS Login will disable Compute Engine instance SSH key metadata from
working, thus making the quickstart fail to install.